### PR TITLE
feat: add support for new control plane node role

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/master
                     operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
               {{- end }}
       containers:
         - name: keepalived


### PR DESCRIPTION
This PR adds support for the new control plane node role (`node-role.kubernetes.io/control-plane`).
This PR does not remove support for the old `node-role.kubernetes.io/master` role.